### PR TITLE
fix and use heap to sort limited peers

### DIFF
--- a/routing/sort_node_cont.go
+++ b/routing/sort_node_cont.go
@@ -1,0 +1,210 @@
+package routing
+
+import (
+	"container/heap"
+	"fmt"
+)
+
+type SortNode struct {
+	dis int
+	*Node
+}
+
+func (sn *SortNode) String() string {
+	return fmt.Sprintf("dis:%v", sn.dis)
+}
+
+// keep size entries that have minimum distance
+type SortNodeHeap struct {
+	entries  []SortNode
+	size     int
+	targetID Hash
+}
+
+func (snh *SortNodeHeap) Init(size int, targetID Hash) {
+	snh.entries = make([]SortNode, size)
+	snh.targetID = targetID
+}
+
+func (snh SortNodeHeap) Len() int {
+	return snh.size
+}
+
+func (snh SortNodeHeap) Less(i, j int) bool {
+	return snh.entries[i].dis >= snh.entries[j].dis
+}
+
+func (snh SortNodeHeap) Swap(i, j int) {
+	snh.entries[i], snh.entries[j] = snh.entries[j], snh.entries[i]
+}
+
+func (snh *SortNodeHeap) Push(x interface{}) {
+	if snh.size == len(snh.entries) {
+		return
+	}
+	snh.entries[snh.size] = x.(SortNode)
+	snh.size++
+}
+
+func (snh *SortNodeHeap) PushNode(n *Node) {
+	sn := SortNode{
+		dis:  distance(n.GetID(), snh.targetID),
+		Node: n,
+	}
+	snh.PushSNode(sn)
+}
+
+func (snh *SortNodeHeap) PushSNode(sn SortNode) {
+	if snh.size == len(snh.entries) {
+		if snh.entries[0].dis < sn.dis {
+			return
+		}
+		snh.PopNode()
+	}
+	heap.Push(snh, sn)
+}
+
+func (snh *SortNodeHeap) PopNode() (sn SortNode, ok bool) {
+	r := heap.Pop(snh)
+	if r != nil {
+		sn = r.(SortNode)
+		ok = true
+	}
+	return
+}
+
+func (snh *SortNodeHeap) ToINodeSlc() []INode {
+	inodes := make([]INode, snh.size)
+	for i := 0; i < snh.size; i++ {
+		inodes[i] = snh.entries[i].Node
+	}
+	return inodes
+}
+
+func (snh *SortNodeHeap) ToNodeSlc() []*Node {
+	inodes := make([]*Node, snh.size)
+	for i := 0; i < snh.size; i++ {
+		inodes[i] = snh.entries[i].Node
+	}
+	return inodes
+}
+
+func (snh *SortNodeHeap) Exec(exec func(n *Node) bool) bool {
+	for i := 0; i < snh.size; i++ {
+		if !exec(snh.entries[i].Node) {
+			return false
+		}
+	}
+	return true
+}
+
+func (snh *SortNodeHeap) Full() bool {
+	return snh.size == len(snh.entries)
+}
+
+// Pop() pops the node with minimum distance
+func (snh *SortNodeHeap) Pop() interface{} {
+	if snh.size == 0 {
+		return nil
+	}
+	ret := snh.entries[snh.size-1]
+	snh.entries[snh.size-1] = SortNode{}
+	snh.size--
+	return ret
+
+}
+
+func (snh *SortNodeHeap) GetMin() (sn SortNode, minIndex int) {
+	if snh.size == 0 {
+		return sn, -1
+	}
+	if snh.size == 1 {
+		return snh.entries[0], 0
+	}
+	lastP := (snh.size)>>2 - 1
+	minIndex = snh.size - 1
+	min := snh.entries[minIndex].dis
+	for i := minIndex; i > lastP; i-- {
+		if snh.entries[i].dis < min {
+			minIndex = i
+			min = snh.entries[minIndex].dis
+		}
+	}
+	sn = snh.entries[minIndex]
+	return
+}
+
+func (snh *SortNodeHeap) Remove(i int) (sn SortNode, ok bool) {
+	r := heap.Remove(snh, i)
+	if r != nil {
+		sn = r.(SortNode)
+		ok = true
+	}
+	return
+}
+
+func (snh *SortNodeHeap) Print() {
+	fmt.Println("heap:", snh.entries, ",size:", snh.size)
+}
+
+////////////////////////////////////////////////////////////////
+
+type NodeRoundQueue struct {
+	nodes       []*Node
+	front, tail int
+}
+
+func NewNodeRoundQueue(size int) *NodeRoundQueue {
+	return &NodeRoundQueue{
+		nodes: make([]*Node, size+1),
+	}
+}
+
+func (l *NodeRoundQueue) Push(n *Node) {
+	if l.Full() {
+		l.Out()
+	}
+	l.nodes[l.tail] = n
+	l.tail = (l.tail + 1) % len(l.nodes)
+}
+
+func (l *NodeRoundQueue) Len() int    { return (l.tail + len(l.nodes) - l.front) % len(l.nodes) }
+func (l *NodeRoundQueue) Full() bool  { return (l.tail+1)%len(l.nodes) == l.front }
+func (l *NodeRoundQueue) Empty() bool { return l.front == l.tail }
+func (l *NodeRoundQueue) Reset()      { l.tail = 0; l.front = 0 }
+func (l *NodeRoundQueue) Out() (*Node, bool) {
+	if l.Empty() {
+		return nil, false
+	}
+	v := l.nodes[l.front]
+	l.front = (l.front + 1) % len(l.nodes)
+	return v, true
+}
+
+func (l *NodeRoundQueue) DataSlc() []*Node {
+	if l.front <= l.tail {
+		return l.nodes[l.front:l.tail]
+	}
+	return append(l.nodes[:l.tail], l.nodes[l.front:]...)
+}
+
+////////////////////////////////////////////////////////////////
+
+type nodesByDistance struct {
+	entries []*Node
+	target  Hash
+}
+
+func (h *nodesByDistance) push(n *Node, maxElems int) {
+	h.entries = append(h.entries, n)
+	for i, node := range h.entries {
+		if distance(node.GetID(), h.target) > distance(n.GetID(), h.target) {
+			copy(h.entries[i+1:], h.entries[i:])
+			h.entries[i] = n
+			break
+		}
+	}
+	if len(h.entries) > maxElems {
+		h.entries = h.entries[:maxElems]
+	}
+}

--- a/routing/sort_node_cont_test.go
+++ b/routing/sort_node_cont_test.go
@@ -1,0 +1,197 @@
+package routing
+
+import (
+	crand "crypto/rand"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+)
+
+func genSortNodeForTest(dis int) SortNode {
+	return SortNode{
+		dis:  dis,
+		Node: &Node{Time: int64(dis)},
+	}
+}
+
+func genNodeForTest() *Node {
+	node := &Node{}
+	node.ID = NewHash()
+	crand.Read(node.ID)
+	return node
+}
+
+func popAndCheckRes(t *testing.T, seq int, sh *SortNodeHeap, size int, sortSlc sort.IntSlice) {
+	if sh.Len() != size {
+		t.Error("unexpected size", seq)
+		return
+	}
+	sort.Sort(sortSlc)
+	sortSlc = sortSlc[:size]
+	var i int
+	for sh.Len() != 0 {
+		if i >= len(sortSlc) {
+			t.Error("out of length of sortslc", seq)
+			return
+		}
+		popn, ok := sh.PopNode()
+		if !ok {
+			t.Error("len() wrong, pop no node", seq)
+			return
+		}
+		curDis := popn.dis
+		if sortSlc[len(sortSlc)-i-1] != curDis {
+			t.Error("seq:", seq, ",unexpected result:", curDis, ",should:", sortSlc[i])
+			return
+		}
+		i++
+	}
+}
+
+func TestSortNodeHeap(t *testing.T) {
+	const (
+		HEAP_SIZE = 10
+	)
+
+	rd := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// num of nodes is equal to heap size
+	sh := &SortNodeHeap{}
+	sh.Init(HEAP_SIZE, nil)
+	sortSlc := make(sort.IntSlice, HEAP_SIZE)
+	for i := range sortSlc {
+		sortSlc[i] = rd.Intn(666)
+		sh.PushSNode(genSortNodeForTest(sortSlc[i]))
+	}
+	popAndCheckRes(t, 1, sh, HEAP_SIZE, sortSlc)
+
+	// num of nodes is smaller than heap size
+	sh.Init(HEAP_SIZE-5, nil)
+	sortSlc = make(sort.IntSlice, HEAP_SIZE-5)
+	for i := range sortSlc {
+		sortSlc[i] = rd.Intn(666)
+		sh.PushSNode(genSortNodeForTest(sortSlc[i]))
+	}
+	popAndCheckRes(t, 2, sh, HEAP_SIZE-5, sortSlc)
+
+	// num of nodes is bigger than heap size
+	sh.Init(HEAP_SIZE, nil)
+	sortSlc = make(sort.IntSlice, HEAP_SIZE+100)
+	for i := range sortSlc {
+		sortSlc[i] = rd.Intn(666)
+		sh.PushSNode(genSortNodeForTest(sortSlc[i]))
+	}
+	popAndCheckRes(t, 3, sh, HEAP_SIZE, sortSlc)
+
+	// has same distance
+	sh.Init(HEAP_SIZE, nil)
+	sortSlc = make(sort.IntSlice, HEAP_SIZE)
+	for i := range sortSlc {
+		sortSlc[i] = rd.Intn(HEAP_SIZE - 5)
+		sh.PushSNode(genSortNodeForTest(sortSlc[i]))
+	}
+	popAndCheckRes(t, 4, sh, HEAP_SIZE, sortSlc)
+
+	// getMin method
+	sh.Init(HEAP_SIZE, nil)
+	sortSlc = make(sort.IntSlice, HEAP_SIZE)
+	for i := range sortSlc {
+		sortSlc[i] = rd.Intn(666)
+		sh.PushSNode(genSortNodeForTest(sortSlc[i]))
+	}
+	sort.Sort(sortSlc)
+	for i := 0; i < 3; i++ {
+		res, resi := sh.GetMin()
+		shouldi := i
+		if sortSlc[shouldi] != res.dis {
+			t.Error("not minimum node", res.dis, ",should:", sortSlc[shouldi])
+			sh.Print()
+			return
+		}
+		rmv, ok := sh.Remove(resi)
+		if !ok || rmv.dis != res.dis {
+			t.Error("remove wrong", ok, rmv.dis, ",should:", res.dis)
+			return
+		}
+	}
+	popAndCheckRes(t, 5, sh, HEAP_SIZE-3, sortSlc[3:])
+}
+
+func TestNodsByDisAndSortHeap(t *testing.T) {
+	const (
+		HEAP_SIZE = 10
+	)
+	targetID := NewHash()
+
+	nodeByDis := &nodesByDistance{target: targetID}
+
+	sh := &SortNodeHeap{}
+	sh.Init(HEAP_SIZE, targetID)
+
+	for i := 0; i < HEAP_SIZE*10; i++ {
+		node := genNodeForTest()
+		sh.PushNode(node)
+		nodeByDis.push(node, HEAP_SIZE)
+	}
+
+	if sh.size != HEAP_SIZE {
+		t.Error("wrong heap size,want:", HEAP_SIZE, ",in real:", sh.size)
+		return
+	}
+	if len(nodeByDis.entries) != HEAP_SIZE {
+		t.Error("wrong nodebydis size,want:", HEAP_SIZE, ",in real:", len(nodeByDis.entries))
+		return
+	}
+
+	disCountsH := make(map[int]int) // map[distance]count
+	for _, nodes := range sh.ToNodeSlc() {
+		disCountsH[distance(nodes.ID, sh.targetID)] += 1
+	}
+	disCountsD := make(map[int]int) // map[distance]count
+	for i := range nodeByDis.entries {
+		nd := nodeByDis.entries[i]
+		disCountsD[distance(nd.ID, nodeByDis.target)] += 1
+	}
+	// different sort methods may result to different id set,
+	// but the counts of different distances are the same
+	for k, v := range disCountsD {
+		if disCountsH[k] != v {
+			t.Error("different distance count between nodeByDis and nodeHeap")
+			return
+		}
+	}
+}
+
+var sortBenchSlc []*Node
+var sortTarget Hash
+
+const (
+	SORT_TABLE_SIZE = 16
+	BENCH_DATA_SIZE = SORT_TABLE_SIZE * 3
+)
+
+func init() {
+	Init(NewConfigurable())
+	sortBenchSlc = make([]*Node, BENCH_DATA_SIZE)
+	for i := range sortBenchSlc {
+		sortBenchSlc[i] = genNodeForTest()
+	}
+	sortTarget = NewHash()
+	crand.Read(sortTarget)
+}
+
+func BenchmarkPushNodeHeap(b *testing.B) {
+	sh := &SortNodeHeap{}
+	sh.Init(SORT_TABLE_SIZE, sortTarget)
+	for i := 0; i < b.N; i++ {
+		sh.PushNode(sortBenchSlc[i%len(sortBenchSlc)])
+	}
+}
+
+func BenchmarkPushNodeOrig(b *testing.B) {
+	h := &nodesByDistance{target: sortTarget}
+	for i := 0; i < b.N; i++ {
+		h.push(sortBenchSlc[i%len(sortBenchSlc)], SORT_TABLE_SIZE)
+	}
+}

--- a/routing/table.go
+++ b/routing/table.go
@@ -588,6 +588,7 @@ func (t *Table) getNodesByNetCallback(targetID Hash, deal DealOnGetNodeFunc, mus
 	t.mutex.Unlock()
 	cctx, cancel := ctx.WithCancel(ctx.Background())
 
+OUT_FOR:
 	for {
 		for i := 0; i < len(result.entries) && pendingQueries < c.alpha; i++ {
 			n := result.entries[i]
@@ -611,7 +612,7 @@ func (t *Table) getNodesByNetCallback(targetID Hash, deal DealOnGetNodeFunc, mus
 					if targetID.Equal(n.GetID()) {
 						ret = []*Node{n}
 						cancel()
-						break
+						break OUT_FOR
 					}
 				}
 				if !seen[nodeKey] {


### PR DESCRIPTION
1. fix misusing break in getNodesByNetCallback method;
2. use heap to sort limited peers to reduce re-allocate slice in sorting.